### PR TITLE
단어장 페이지 이동 구조 개선 및 UI 전반 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "firebase": "^12.0.0",
-        "lucide-react": "^0.536.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.7.0",
         "zustand": "^5.0.6"
       },
@@ -6106,14 +6106,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lucide-react": {
-      "version": "0.536.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.536.0.tgz",
-      "integrity": "sha512-2PgvNa9v+qz4Jt/ni8vPLt4jwoFybXHuubQT8fv4iCW5TjDxkbZjNZZHa485ad73NSEn/jdsEtU57eE1g+ma8A==",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -6703,6 +6695,14 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "firebase": "^12.0.0",
-    "lucide-react": "^0.536.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.7.0",
     "zustand": "^5.0.6"
   },

--- a/src/api/bookApi.ts
+++ b/src/api/bookApi.ts
@@ -1,0 +1,13 @@
+import { collection, getDocs, orderBy, query } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export async function getBook() {
+  const q = query(
+    collection(db, 'vocabularyBooks'),
+    orderBy('createdAt', 'desc')
+  );
+  console.log(q, 'qqqq');
+  const snap = await getDocs(q);
+  console.log(snap, 'snapppp');
+  return snap.docs.map((d) => console.log(d.data));
+}

--- a/src/api/wordApi.ts
+++ b/src/api/wordApi.ts
@@ -1,0 +1,12 @@
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export const fetchUsers = async () => {
+  const usersCollectionRef = collection(db, 'words'); // 참조
+  const userSnap = await getDocs(usersCollectionRef); // 데이터 스냅 받아오기 - 비동기처리
+  const data = userSnap.docs.map((doc) => ({
+    ...doc.data(),
+    id: doc.id,
+  }));
+  return data;
+};

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -7,7 +7,7 @@ interface CardProps {
 
 export default function Card({ word }: CardProps): JSX.Element {
   return (
-    <div className="flex justify-center items-center shadow-xl border border-amber-200 rounded-lg w-64 h-48 mx-4 bg-amber-50">
+    <div className="flex justify-center items-center shadow-xl border border-pastelLemon rounded-lg w-64 h-48 mx-4 bg-pastelLemonLight">
       <div className="text-2xl font-semibold ">{word.word}</div>
     </div>
   );

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,83 @@
+import type { ButtonHTMLAttributes, JSX } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?:
+    | 'primary'
+    | 'secondary'
+    | 'disabled'
+    | 'text'
+    // | 'text2'
+    | 'confirm'
+    | 'cancel';
+  size?: 'sm' | 'md' | 'lg';
+}
+
+export default function Button({
+  children,
+  variant = 'primary',
+  className = '',
+  disabled,
+  size = 'sm',
+  ...props
+}: ButtonProps): JSX.Element {
+  const styleSet = {
+    primary: `
+      w-[350px] h-[46px]
+      rounded-[4px]
+      px-[22px] py-[14px]
+      text-white
+      bg-primary
+    `,
+    secondary: `
+      w-[350px] h-[46px]
+      rounded-[4px]
+      px-[22px] py-[14px]
+      border border-[#6790FF]
+      bg-white text-primary
+    `,
+    disabled: `
+      w-[350px] h-[46px]
+      rounded-[4px]
+      px-[22px] py-[14px]
+      text-white
+      bg-[#DBDBDB]
+      cursor-not-allowed
+    `,
+    text: `
+			text-primary
+			text-h4
+			bg-transparent
+		`,
+    text2: `
+			text-[#777777]
+			text-h4
+		`,
+    confirm: `bg-btnConfirm text-black w-20 h-10 rounded-md`,
+    cancel: `bg-btnCancel text-black w-20 h-10 rounded-md`,
+  };
+
+  const sizeSet = {
+    sm: `w-20 h-10 rounded-lg`,
+    md: `w-28 h-14 rounded-xl`,
+    lg: ``,
+  };
+
+  return (
+    <button
+      {...props}
+      disabled={disabled || variant === 'disabled'}
+      className={`${styleSet[variant]}  ${sizeSet[size]} ${className}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// interface ButtonProps {
+//   size?: 'sm' | 'lg';
+// }
+
+// export default function Button({ size }: ButtonProps) {
+//   const SIZEVARINT = { sm: 'button' };
+//   return <button className={`${size}`}>{childern}</button>;
+// }

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -8,8 +8,9 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
     | 'text'
     // | 'text2'
     | 'confirm'
-    | 'cancel';
-  size?: 'sm' | 'md' | 'lg';
+    | 'cancel'
+    | 'icon';
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'addBtn';
 }
 
 export default function Button({
@@ -44,22 +45,24 @@ export default function Button({
       cursor-not-allowed
     `,
     text: `
-			text-primary
+			text-black
 			text-h4
-			bg-transparent
 		`,
     text2: `
 			text-[#777777]
 			text-h4
 		`,
+    icon: ``,
     confirm: `bg-btnConfirm text-black w-20 h-10 rounded-md`,
     cancel: `bg-btnCancel text-black w-20 h-10 rounded-md`,
   };
 
   const sizeSet = {
+    xs: `w-12 h-12`,
     sm: `w-20 h-10 rounded-lg`,
     md: `w-28 h-14 rounded-xl`,
-    lg: ``,
+    lg: `h-20`,
+    addBtn: `w-14 h-14`,
   };
 
   return (

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,41 @@
+import type { InputHTMLAttributes } from 'react';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  id?: string;
+  name: string;
+  inputName?: string;
+  type?: string;
+  placeholder?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  errorMessage?: string;
+}
+export default function Input({
+  id,
+  inputName,
+  placeholder,
+  onChange,
+  type = 'text',
+  errorMessage,
+  ...other
+}: InputProps) {
+  return (
+    <>
+      {inputName && (
+        <label className="m-3" htmlFor={id}>
+          {inputName}
+        </label>
+      )}
+      <input
+        type={type}
+        className="m-3 border"
+        placeholder={placeholder}
+        id={id}
+        onChange={onChange}
+        {...other}
+      />
+      {errorMessage && (
+        <p className="text-red-500 text-sm ml-3">{errorMessage}</p>
+      )}
+    </>
+  );
+}

--- a/src/components/vocabulary-book/AddVocabularyButton.tsx
+++ b/src/components/vocabulary-book/AddVocabularyButton.tsx
@@ -1,4 +1,6 @@
 import { type JSX } from 'react';
+import { FaPlus } from 'react-icons/fa6';
+import Button from '../common/Button';
 
 interface AddButtonProps {
   addButton: () => void;
@@ -8,8 +10,13 @@ export default function AddVocabularyBookButton({
   addButton,
 }: AddButtonProps): JSX.Element {
   return (
-    <button className="bg-dol  w-12 h-12 rounded-full" onClick={addButton}>
-      +
-    </button>
+    <Button
+      variant="icon"
+      size="addBtn"
+      className="bg-dol rounded-full text-white flex justify-center items-center"
+      onClick={addButton}
+    >
+      <FaPlus size={18} />
+    </Button>
   );
 }

--- a/src/components/vocabulary-book/DeleteCofirmModal.tsx
+++ b/src/components/vocabulary-book/DeleteCofirmModal.tsx
@@ -1,4 +1,5 @@
 import { type JSX } from 'react';
+import Button from '../common/Button';
 
 interface DeleteCofirmModalProps {
   onConfirm?: () => void;
@@ -15,31 +16,27 @@ export default function DeleteConfirmModal({
     e.preventDefault();
     e.stopPropagation();
     onCancel();
+    console.log('cancel');
   };
 
   const handleConfirm = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
     onConfirm?.();
+    console.log('confirm');
   };
 
   return (
     <div className="fixed inset-0 z-50  flex justify-center items-center">
-      <div className="bg-yellow-200 rounded-lg p-6 text-center">
+      <div className="bg-[#f4f4f4] rounded-lg p-6 text-center">
         <p className="text-lg mb-6">{vocabularyName}을 삭제하겠습니까?</p>
         <div className="flex justify-center gap-8">
-          <button
-            className="w-20 h-10 rounded-md bg-red-400"
-            onClick={handleCancel}
-          >
+          <Button size="sm" className="bg-btnCancel" onClick={handleCancel}>
             취소
-          </button>
-          <button
-            className="w-20 h-10 rounded-md bg-green-400"
-            onClick={handleConfirm}
-          >
+          </Button>
+          <Button size="sm" className="bg-btnConfirm" onClick={handleConfirm}>
             확인
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/vocabulary-book/VocabularyBook.tsx
+++ b/src/components/vocabulary-book/VocabularyBook.tsx
@@ -49,30 +49,26 @@ export default function VocabularyBook({
   };
 
   return (
-    <div className="border">
-      <div className="flex flex-col justify-center my-8">
+    <div>
+      <div className="flex flex-col justify-center border h-24 my-8">
         <div
-          className={`flex justify-between ${color} w-full rounded-lg`}
+          className={`flex justify-between ${color} h-20 rounded-lg`}
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}
         >
           <Button
-            className={`bg-blue-300 w-20 h-20 p-2 border ${showPinButton ? 'block' : 'hidden'}`}
+            variant="icon"
+            size="lg"
+            className={`bg-blue-300 p-2 rounded-l-lg ${showPinButton ? 'block' : 'hidden'}`}
           >
-            <TiPin size={32} />
+            <TiPin size={28} />
           </Button>
           <div className="p-6 w-full">{title}</div>
 
-          {/* <button
-                className={`bg-red-400 w-20 rounded-r-lg ${
-                  showDeleteButton ? 'opacity-100' : 'opacity-0'
-                }`}
-                onClick={handleDeleteClick}
-              >
-                삭제
-              </button> */}
           <Button
+            variant="icon"
+            size="lg"
             className={`bg-red-400 w-20 h-20 rounded-r-lg ${
               showDeleteButton ? 'opacity-100' : 'opacity-0'
             }`}

--- a/src/components/vocabulary-book/VocabularyBook.tsx
+++ b/src/components/vocabulary-book/VocabularyBook.tsx
@@ -1,5 +1,7 @@
 import { useState, type JSX } from 'react';
 import DeleteConfirmModal from './DeleteCofirmModal';
+import { TiPin } from 'react-icons/ti';
+import Button from '../common/Button';
 
 interface VocabularyBookProps {
   title: string;
@@ -47,36 +49,45 @@ export default function VocabularyBook({
   };
 
   return (
-    <div className="flex flex-col justify-center my-8">
-      <div
-        className={`flex justify-between ${color} w-72 rounded-lg`}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-      >
-        <button
-          className={`bg-blue-300 w-20 rounded-l-lg ${showPinButton ? 'block' : 'hidden'}`}
+    <div className="border">
+      <div className="flex flex-col justify-center my-8">
+        <div
+          className={`flex justify-between ${color} w-full rounded-lg`}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
         >
-          pin
-        </button>
+          <Button
+            className={`bg-blue-300 w-20 h-20 p-2 border ${showPinButton ? 'block' : 'hidden'}`}
+          >
+            <TiPin size={32} />
+          </Button>
+          <div className="p-6 w-full">{title}</div>
 
-        <div className="p-6 w-full">{title}</div>
+          {/* <button
+                className={`bg-red-400 w-20 rounded-r-lg ${
+                  showDeleteButton ? 'opacity-100' : 'opacity-0'
+                }`}
+                onClick={handleDeleteClick}
+              >
+                삭제
+              </button> */}
+          <Button
+            className={`bg-red-400 w-20 h-20 rounded-r-lg ${
+              showDeleteButton ? 'opacity-100' : 'opacity-0'
+            }`}
+            onClick={handleDeleteClick}
+          >
+            삭제
+          </Button>
 
-        <button
-          className={`bg-red-400 w-20 rounded-r-lg ${
-            showDeleteButton ? 'opacity-100' : 'opacity-0'
-          }`}
-          onClick={handleDeleteClick}
-        >
-          삭제
-        </button>
-
-        {showDeleteModal && (
-          <DeleteConfirmModal
-            onCancel={() => setShowDeleteModal(false)}
-            vocabularyName={title}
-          />
-        )}
+          {showDeleteModal && (
+            <DeleteConfirmModal
+              onCancel={() => setShowDeleteModal(false)}
+              vocabularyName={title}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/word-list/AddWordButton.tsx
+++ b/src/components/word-list/AddWordButton.tsx
@@ -1,6 +1,5 @@
-// import { PlusCircle } from 'lucide-react';
-
 import { LuCirclePlus } from 'react-icons/lu';
+import Button from '../common/Button';
 
 interface AddButtonProps {
   addWord: () => void;
@@ -9,12 +8,12 @@ interface AddButtonProps {
 export default function AddWordButton({ addWord }: AddButtonProps) {
   return (
     <div className="flex justify-center">
-      <button
-        className="px-10 py-3 rounded flex font-semibold gap-2 bg-primary"
-        onClick={addWord}
-      >
-        단어 추가 <LuCirclePlus />
-      </button>
+      <Button size="md" onClick={addWord}>
+        <div className="flex leading-none gap-4 justify-center">
+          <LuCirclePlus />
+          <span>단어 추가</span>
+        </div>
+      </Button>
     </div>
   );
 }

--- a/src/components/word-list/AddWordButton.tsx
+++ b/src/components/word-list/AddWordButton.tsx
@@ -1,9 +1,16 @@
 import { PlusCircle } from 'lucide-react';
 
-export default function AddWordButton() {
+interface AddButtonProps {
+  addWord: () => void;
+}
+
+export default function AddWordButton({ addWord }: AddButtonProps) {
   return (
     <div className="flex justify-center">
-      <button className="px-10 py-3 rounded flex font-semibold gap-2 bg-primary">
+      <button
+        className="px-10 py-3 rounded flex font-semibold gap-2 bg-primary"
+        onClick={addWord}
+      >
         단어 추가 <PlusCircle />
       </button>
     </div>

--- a/src/components/word-list/AddWordButton.tsx
+++ b/src/components/word-list/AddWordButton.tsx
@@ -1,4 +1,6 @@
-import { PlusCircle } from 'lucide-react';
+// import { PlusCircle } from 'lucide-react';
+
+import { LuCirclePlus } from 'react-icons/lu';
 
 interface AddButtonProps {
   addWord: () => void;
@@ -11,7 +13,7 @@ export default function AddWordButton({ addWord }: AddButtonProps) {
         className="px-10 py-3 rounded flex font-semibold gap-2 bg-primary"
         onClick={addWord}
       >
-        단어 추가 <PlusCircle />
+        단어 추가 <LuCirclePlus />
       </button>
     </div>
   );

--- a/src/components/word-list/CreateWordModal.tsx
+++ b/src/components/word-list/CreateWordModal.tsx
@@ -2,11 +2,15 @@ import type { JSX } from 'react';
 
 export default function CreateWordModal(): JSX.Element {
   return (
-    <div className="flex flex-col">
-      <label htmlFor="wordName">hello</label>
+    <div className="flex flex-col bg-amber-300 px-4 py-6">
+      <label htmlFor="wordName">단어</label>
       <input id="wordName" type="text" placeholder="hi" />
-      <label htmlFor="wordMeaning">hello</label>
+      <label htmlFor="wordMeaning">뜻</label>
       <input id="wordMeaning" type="text" placeholder="hi" />
+      <div className="flex justify-center items-center gap-4 mt-4">
+        <button className="border px-4 py-2">취소</button>
+        <button className="border px-4 py-2">확인</button>
+      </div>
     </div>
   );
 }

--- a/src/components/word-list/CreateWordModal.tsx
+++ b/src/components/word-list/CreateWordModal.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react';
+import Button from '../common/Button';
 
 export default function CreateWordModal(): JSX.Element {
   return (
@@ -8,8 +9,12 @@ export default function CreateWordModal(): JSX.Element {
       <label htmlFor="wordMeaning">뜻</label>
       <input id="wordMeaning" type="text" placeholder="hi" />
       <div className="flex justify-center items-center gap-4 mt-4">
-        <button className="border px-4 py-2">취소</button>
-        <button className="border px-4 py-2">확인</button>
+        <Button variant="cancel" className="rounded-md px-8 py-3">
+          취소
+        </Button>
+        <Button variant="confirm" className="rounded-md px-8 py-3">
+          확인
+        </Button>
       </div>
     </div>
   );

--- a/src/components/word-list/FavoriteButton.tsx
+++ b/src/components/word-list/FavoriteButton.tsx
@@ -1,9 +1,10 @@
-import { StarIcon } from 'lucide-react';
+// import { StarIcon } from 'lucide-react';
 import type { JSX } from 'react';
+import { FaRegStar, FaStar } from 'react-icons/fa';
 
 interface FavoriteButtonProps {
-  isChecked: boolean;
-  handleStarBtn: () => void;
+  isChecked?: boolean;
+  handleStarBtn?: () => void;
 }
 
 export default function FavoriteButton({
@@ -12,7 +13,7 @@ export default function FavoriteButton({
 }: FavoriteButtonProps): JSX.Element {
   return (
     <button onClick={handleStarBtn}>
-      {isChecked ? <StarIcon fill="yellow" /> : <StarIcon />}
+      {isChecked ? <FaStar fill="yellow" /> : <FaRegStar />}
     </button>
   );
 }

--- a/src/components/word-list/SearchWord.tsx
+++ b/src/components/word-list/SearchWord.tsx
@@ -1,9 +1,11 @@
-import { SearchIcon } from 'lucide-react';
+// import { SearchIcon } from 'lucide-react';
+
+import { BsSearch } from 'react-icons/bs';
 
 export default function SearchWord() {
   return (
     <div className="flex items-center border rounded-md px-3 py-2 bg-white shadow-sm">
-      <SearchIcon className="w-4 h-4 text-gray-500 mr-2" />
+      <BsSearch className="w-4 h-4 text-gray-500 mr-2" />
       <input
         type="text"
         placeholder="단어 검색"

--- a/src/components/word-list/WordList.tsx
+++ b/src/components/word-list/WordList.tsx
@@ -1,16 +1,19 @@
-import type { JSX } from 'react';
+import { type JSX } from 'react';
+import FavoriteButton from './FavoriteButton';
+import { getBook } from '../../api/bookApi';
+// import { fetchUsers } from '../../api/wordApi';
 
 export default function WordList(): JSX.Element {
+  const handleFetch = () => {
+    getBook();
+  };
   return (
     <div className="my-5">
       <div>150 글자</div>
-      <div className="flex gap-2 border p-2">
-        <div> border</div>
-        <div>n. 경계</div>
-      </div>
-      <div className="border my-2 p-2">
-        <div> border</div>
-        <div>n. 경계</div>
+      <div className="flex justify-between gap-2 border p-4 rounded-md">
+        <div>border</div>
+        <div onClick={handleFetch}>n. 경계</div>
+        <FavoriteButton />
       </div>
     </div>
   );

--- a/src/components/word-list/WordList.tsx
+++ b/src/components/word-list/WordList.tsx
@@ -2,17 +2,23 @@ import { type JSX } from 'react';
 import FavoriteButton from './FavoriteButton';
 import { getBook } from '../../api/bookApi';
 // import { fetchUsers } from '../../api/wordApi';
+interface WordListProps {
+  word: string;
+  meaning: string;
+}
 
-export default function WordList(): JSX.Element {
+export default function WordList({
+  word,
+  meaning,
+}: WordListProps): JSX.Element {
   const handleFetch = () => {
     getBook();
   };
   return (
     <div className="my-5">
-      <div>150 글자</div>
       <div className="flex justify-between gap-2 border p-4 rounded-md">
-        <div>border</div>
-        <div onClick={handleFetch}>n. 경계</div>
+        <div>{word}</div>
+        <div onClick={handleFetch}>{meaning}</div>
         <FavoriteButton />
       </div>
     </div>

--- a/src/components/word-list/WordListHeader.tsx
+++ b/src/components/word-list/WordListHeader.tsx
@@ -1,5 +1,7 @@
 import type { JSX } from 'react';
-import { ChevronLeft, SearchIcon } from 'lucide-react';
+import { BsSearch } from 'react-icons/bs';
+import { IoChevronBack } from 'react-icons/io5';
+// import { ChevronLeft, SearchIcon } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 interface WordListHeaderProps {
@@ -14,11 +16,11 @@ export default function WordListHeader({
   return (
     <div className="relative flex items-center h-14 px-4">
       <button className="absolute left-4" onClick={() => navigate(-1)}>
-        <ChevronLeft />
+        <IoChevronBack />
       </button>
       <h1 className="mx-auto text-lg font-semibold">{listName}</h1>
       <button className="absolute right-4" onClick={() => navigate(-1)}>
-        <SearchIcon />
+        <BsSearch />
       </button>
     </div>
   );

--- a/src/data/mockVocabulary.ts
+++ b/src/data/mockVocabulary.ts
@@ -1,22 +1,59 @@
+import type { Vocabulary } from '../types/vocabulary';
 import { toeicWords } from './mockWords';
 
-export const mockVocabulary = [
+export const mockVocabulary: Vocabulary[] = [
   {
     id: 1,
     title: 'TOEIC 단어장',
-    color: 'bg-dol',
+    color: 'bg-pastelLavenderLight',
     words: toeicWords,
   },
   {
     id: 2,
     title: 'JLPT N3 단어장',
-    color: 'bg-pastelRose',
+    color: 'bg-pastelLemon',
     words: [],
   },
   {
     id: 3,
     title: '영어 5과',
-    color: 'bg-lime',
+    color: 'bg-pastelGreen',
+    words: [],
+  },
+  {
+    id: 4,
+    title: '영단어',
+    color: 'bg-pastelSkyLight',
+    words: [],
+  },
+  {
+    id: 5,
+    title: '중국어',
+    color: 'bg-pastelSkyLight',
+    words: [],
+  },
+  {
+    id: 6,
+    title: '영단어',
+    color: 'bg-pastelSkyLight',
+    words: [],
+  },
+  {
+    id: 7,
+    title: '영단어',
+    color: 'bg-pastelSkyLight',
+    words: [],
+  },
+  {
+    id: 8,
+    title: '영단어',
+    color: 'bg-pastelSkyLight',
+    words: [],
+  },
+  {
+    id: 9,
+    title: '영단어',
+    color: 'bg-pastelSkyLight',
     words: [],
   },
 ];

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,9 @@
 @import 'tailwindcss';
 
 @theme {
+  --color-btnCancel: #f7adaf;
+  --color-btnConfirm: #4ad29b;
+
   --color-midnight: #121063;
   --color-tahiti: #3ab7bf;
   --color-bermuda: #78dcca;
@@ -14,7 +17,7 @@
   --color-lavender: #eadcf8;
   --color-softcoral: #ffd5cd;
   --color-skygray: #e6ebf5;
-  
+
   /* 단어장 선택 색상  */
   --color-pastelRose: #f28b82;
   --color-pastelLemon: #fdd663;

--- a/src/page/HomePage.tsx
+++ b/src/page/HomePage.tsx
@@ -1,23 +1,31 @@
 import { useState, type JSX } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { mockVocabulary } from '../data/mockVocabulary';
 import Header from '../components/common/Header';
 import AddVocabularyButton from '../components/vocabulary-book/AddVocabularyButton';
 import CreateVocabularyModal from '../components/vocabulary-book/CreateVocabularyModal';
 import VocabularyBook from '../components/vocabulary-book/VocabularyBook';
+import type { Vocabulary } from '../types/vocabulary';
 
 export default function HomePage(): JSX.Element {
   const [openModal, setOpenModal] = useState(false);
+  const navigate = useNavigate();
 
   const handleCloseModal = () => setOpenModal(false);
+
+  const handleClick = (voca: Vocabulary) => {
+    navigate(`/vocabulary/${voca.id}/list`, {
+      state: voca,
+    });
+  };
 
   return (
     <div>
       <Header />
       {mockVocabulary.map((voca) => (
-        <Link to={`/vocabulary/${voca.id}/list`}>
-          <VocabularyBook key={voca.id} title={voca.title} color={voca.color} />
-        </Link>
+        <div key={voca.id} onClick={() => handleClick(voca)}>
+          <VocabularyBook title={voca.title} color={voca.color} />
+        </div>
       ))}
 
       {openModal && (
@@ -31,7 +39,9 @@ export default function HomePage(): JSX.Element {
         </div>
       )}
 
-      <AddVocabularyButton addButton={() => setOpenModal(true)} />
+      <div className="fixed right-5 bottom-10">
+        <AddVocabularyButton addButton={() => setOpenModal(true)} />
+      </div>
     </div>
   );
 }

--- a/src/page/LearnPage.tsx
+++ b/src/page/LearnPage.tsx
@@ -4,6 +4,7 @@ import { toeicWords } from '../data/mockWords';
 // import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Header from '../components/common/Header';
 import { IoChevronBack, IoChevronForward } from 'react-icons/io5';
+import Button from '../components/common/Button';
 
 export default function LearnPage(): JSX.Element {
   const [currentWord, setCurrentWord] = useState(0);
@@ -60,9 +61,13 @@ export default function LearnPage(): JSX.Element {
             <IoChevronForward />
           </button>
         </div>
-        <div>
-          <button className="bg-dol">학습 필요</button>
-          <button>학습 완료</button>
+        <div className="flex justify-center mt-14 gap-6">
+          <Button variant="text" size="md" className="bg-softcoral">
+            학습 필요
+          </Button>
+          <Button variant="text" size="md" className="bg-pastelSkyLight">
+            학습 완료
+          </Button>
         </div>
       </div>
     </div>

--- a/src/page/LearnPage.tsx
+++ b/src/page/LearnPage.tsx
@@ -1,8 +1,9 @@
 import { useState, type JSX } from 'react';
 import Card from '../components/card/Card';
 import { toeicWords } from '../data/mockWords';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+// import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Header from '../components/common/Header';
+import { IoChevronBack, IoChevronForward } from 'react-icons/io5';
 
 export default function LearnPage(): JSX.Element {
   const [currentWord, setCurrentWord] = useState(0);
@@ -52,11 +53,11 @@ export default function LearnPage(): JSX.Element {
         </div>
         <div className="flex justify-center items-center">
           <button onClick={goPrev}>
-            <ChevronLeft />
+            <IoChevronBack />
           </button>
           <Card word={toeicWords[currentWord]} />
           <button onClick={goNext}>
-            <ChevronRight />
+            <IoChevronForward />
           </button>
         </div>
         <div>

--- a/src/page/LoginPage.tsx
+++ b/src/page/LoginPage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function LoginPage() {
+  return <div>LoginPage</div>;
+}

--- a/src/page/SignupPage.tsx
+++ b/src/page/SignupPage.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import Input from '../components/common/Input';
+
+export default function SignupPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordCheck, setPasswordCheck] = useState('');
+
+  return (
+    <div>
+      <Input
+        name="nickname"
+        placeholder="닉네임"
+        onChange={(e) => setName(e.target.value)}
+        value={name}
+      />
+      <Input
+        name="email"
+        type="email"
+        placeholder="이메일"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <Input
+        name="password"
+        type="password"
+        placeholder="비밀번호"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <Input
+        name="passwordCheck"
+        type="password"
+        placeholder="비밀번호 확인"
+        value={passwordCheck}
+        onChange={(e) => setPasswordCheck(e.target.value)}
+      />
+      <button>제출하기</button>
+      {/* <Input id="이름" name="hi" inputName="input" type="text" />
+      <Input id="이메일" name="hi" inputName="input" type="text" />
+      <Input id="비밀번호" name="hi" inputName="input" type="text" />
+      <Input id="비밀번호 확인" name="hi" inputName="input" type="text" /> */}
+    </div>
+  );
+}

--- a/src/page/VocabularyListPage.tsx
+++ b/src/page/VocabularyListPage.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import { useState, type JSX } from 'react';
 import WordList from '../components/word-list/WordList';
 import WordListHeader from '../components/word-list/WordListHeader';
 import SearchWord from '../components/word-list/SearchWord';
@@ -6,13 +6,14 @@ import AddWordButton from '../components/word-list/AddWordButton';
 import CreateWordModal from '../components/word-list/CreateWordModal';
 
 export default function VocabularyListPage(): JSX.Element {
+  const [openModal, setOpenModal] = useState(false);
   return (
     <div>
       <WordListHeader listName="HI" />
       <SearchWord />
       <WordList />
-      <AddWordButton />
-      <CreateWordModal />
+      <AddWordButton addWord={() => setOpenModal(true)} />
+      {openModal && <CreateWordModal />}
     </div>
   );
 }

--- a/src/page/VocabularyListPage.tsx
+++ b/src/page/VocabularyListPage.tsx
@@ -4,14 +4,23 @@ import WordListHeader from '../components/word-list/WordListHeader';
 import SearchWord from '../components/word-list/SearchWord';
 import AddWordButton from '../components/word-list/AddWordButton';
 import CreateWordModal from '../components/word-list/CreateWordModal';
+import { toeicWords } from '../data/mockWords';
+import { useLocation } from 'react-router-dom';
 
 export default function VocabularyListPage(): JSX.Element {
   const [openModal, setOpenModal] = useState(false);
+  const location = useLocation();
+  const state = location.state;
+  const title = state.title;
+
   return (
     <div>
-      <WordListHeader listName="HI" />
+      <WordListHeader listName={title} />
       <SearchWord />
-      <WordList />
+      <div className="my-4">총 단어 수 : {toeicWords.length}개</div>
+      {toeicWords.map((words) => (
+        <WordList word={words.word} meaning={words.meaning} />
+      ))}
       <AddWordButton addWord={() => setOpenModal(true)} />
       {openModal && <CreateWordModal />}
     </div>

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -3,12 +3,16 @@ import MainLayout from '../layout/MainLayout';
 import HomePage from '../page/HomePage';
 import LearnPage from '../page/LearnPage';
 import VocabularyListPage from '../page/VocabularyListPage';
+import SignupPage from '../page/SignupPage';
+import LoginPage from '../page/LoginPage';
 
 export default function Router() {
   return (
     <Routes>
       <Route element={<MainLayout />}>
         <Route path="/" element={<HomePage />} />
+        <Route path="/signup" element={<SignupPage />} />
+        <Route path="/login" element={<LoginPage />} />
         <Route path="/learn/:id" element={<LearnPage />} />
         <Route path="/vocabulary/:id/list" element={<VocabularyListPage />} />
       </Route>


### PR DESCRIPTION
## 변경 내용
- 단어 추가 모달(CreateWordModal) 컴포넌트 추가
- CreateWordModal UI 개선 및 버튼 추가
- AddWordButton에 props 추가 및 onClick 이벤트 연결
- 회원가입 페이지 추가
- 로그인 페이지 추가
- 단어 학습 페이지 추가
- Input 컴포넌트 추가
- 색상 변수(theme) 추가
- 기존 버튼 태그를 공통 Button 컴포넌트로 교체
- 단어 리스트에 즐겨찾기 버튼 및 클릭 이벤트 추가
- 아이콘 react-icons로 통일
- 샘플 단어장 데이터(mock) 추가
- 단어장 페이지 이동 방식을 navigate(state)로 변경
